### PR TITLE
chore: fix input proof http call

### DIFF
--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -35,7 +35,7 @@ export const publicDecryptRequest =
     let response;
     let json;
     try {
-      response = await fetch(`${relayerUrl}v1/public-decrypt`, options);
+      response = await fetch(`${relayerUrl}/v1/public-decrypt`, options);
       if (!response.ok) {
         throw new Error(
           `Reencrypt failed: relayer respond with HTTP code ${response.status}`,

--- a/src/relayer/sendEncryption.test.ts
+++ b/src/relayer/sendEncryption.test.ts
@@ -16,12 +16,12 @@ const chainId = 1234;
 const autoMock = (input: RelayerEncryptedInput) => {
   fetchMock.postOnce(`${relayerUrl}/v1/input-proof`, (params: any) => {
     const body = JSON.parse(params.options.body);
-    const ciphertextWithZkpok: string = body.ciphertextWithZkpok;
+    const ciphertextWithInputVerification: string = body.ciphertextWithInputVerification;
     const options = {
-      params: { ciphertextWithZkpok },
+      params: { ciphertextWithInputVerification },
     };
     const handles = computeHandles(
-      fromHexString(ciphertextWithZkpok),
+      fromHexString(ciphertextWithInputVerification),
       input.getBits(),
       aclContractAddress,
       chainId,
@@ -238,9 +238,9 @@ describe('encrypt', () => {
     input.add128(BigInt(1));
     fetchMock.postOnce(`${relayerUrl}/v1/input-proof`, (params: any) => {
       const body = JSON.parse(params.options.body);
-      const ciphertextWithZkpok: string = body.ciphertextWithZkpok;
+      const ciphertextWithInputVerification: string = body.ciphertextWithInputVerification;
       const options = {
-        params: { ciphertextWithZkpok },
+        params: { ciphertextWithInputVerification },
       };
       return {
         options: options,

--- a/src/relayer/sendEncryption.test.ts
+++ b/src/relayer/sendEncryption.test.ts
@@ -16,7 +16,8 @@ const chainId = 1234;
 const autoMock = (input: RelayerEncryptedInput) => {
   fetchMock.postOnce(`${relayerUrl}/v1/input-proof`, (params: any) => {
     const body = JSON.parse(params.options.body);
-    const ciphertextWithInputVerification: string = body.ciphertextWithInputVerification;
+    const ciphertextWithInputVerification: string =
+      body.ciphertextWithInputVerification;
     const options = {
       params: { ciphertextWithInputVerification },
     };
@@ -238,7 +239,8 @@ describe('encrypt', () => {
     input.add128(BigInt(1));
     fetchMock.postOnce(`${relayerUrl}/v1/input-proof`, (params: any) => {
       const body = JSON.parse(params.options.body);
-      const ciphertextWithInputVerification: string = body.ciphertextWithInputVerification;
+      const ciphertextWithInputVerification: string =
+        body.ciphertextWithInputVerification;
       const options = {
         params: { ciphertextWithInputVerification },
       };

--- a/src/relayer/sendEncryption.ts
+++ b/src/relayer/sendEncryption.ts
@@ -134,7 +134,7 @@ export const createRelayerEncryptedInput =
         const payload = {
           contractAddress: getAddress(contractAddress),
           userAddress: getAddress(userAddress),
-          ciphertextWithZkpok: toHexString(ciphertext),
+          ciphertextWithInputVerification: toHexString(ciphertext),
           contractChainId: '0x' + chainId.toString(16),
         };
         const options = {

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -112,7 +112,7 @@ export const userDecryptRequest =
     let response;
     let json;
     try {
-      response = await fetch(`${relayerUrl}v1/user-decrypt`, options);
+      response = await fetch(`${relayerUrl}/v1/user-decrypt`, options);
       if (!response.ok) {
         throw new Error(
           `Reencrypt failed: relayer respond with HTTP code ${response.status}`,


### PR DESCRIPTION
Add / for relayer calls:
convention is not have trailing / in relayer url
Update http endpoint field name:
replace `ciphertextWithInputZkPok` with `ciphertextWithInputVerification`