### PR TITLE
feat: fix API errors, add ACL and signatures check for public decrypt…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fhevm/sdk",
-  "version": "0.7.0-28",
+  "version": "0.7.0-29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fhevm/sdk",
-      "version": "0.7.0-28",
+      "version": "0.7.0-29",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fhevm/sdk",
-  "version": "0.7.0-28",
+  "version": "0.7.0-29",
   "description": "fhevm SDK",
   "main": "lib/node.js",
   "types": "lib/node/node.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,10 @@ import {
 } from './utils';
 import { CompactPkeCrs, TfheCompactPublicKey } from 'node-tfhe';
 
-const abiKmsVerifier = ['function getKmsSigners() view returns (address[])','function getThreshold() view returns (uint256)'];
+const abiKmsVerifier = [
+  'function getKmsSigners() view returns (address[])',
+  'function getThreshold() view returns (uint256)',
+];
 
 export type FhevmInstanceConfig = {
   verifyingContractAddress: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ import {
 } from './utils';
 import { CompactPkeCrs, TfheCompactPublicKey } from 'node-tfhe';
 
-const abiKmsVerifier = ['function getKmsSigners() view returns (address[])'];
+const abiKmsVerifier = ['function getKmsSigners() view returns (address[])','function getThreshold() view returns (uint256)'];
 
 export type FhevmInstanceConfig = {
   verifyingContractAddress: string;
@@ -121,4 +121,17 @@ export const getKMSSigners = async (
   );
   const signers: string[] = await kmsContract.getKmsSigners();
   return signers;
+};
+
+export const getKMSSignersThreshold = async (
+  provider: Provider,
+  config: FhevmInstanceConfig,
+): Promise<number> => {
+  const kmsContract = new Contract(
+    config.kmsContractAddress,
+    abiKmsVerifier,
+    provider,
+  );
+  const threshold: bigint = await kmsContract.getThreshold();
+  return Number(threshold); // threshold is always supposed to fit in a number
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,7 @@ jest.mock('ethers', () => ({
   isAddress: () => true,
   Contract: () => ({
     getKmsSigners: () => ['0x4c102C7cA99d3079fEFF08114d3bad888b9794d9'],
+    getThreshold: () => BigInt(1),
   }),
 }));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export type FhevmInstance = {
   ) => EIP712;
   publicDecrypt: (
     handles: (string | Uint8Array)[],
-  ) => Promise<Record<string, DecryptedResults>>;
+  ) => Promise<DecryptedResults>;
   userDecrypt: (
     handles: HandleContractPair[],
     privateKey: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   FhevmInstanceConfig,
   getChainId,
   getKMSSigners,
+  getKMSSignersThreshold,
   getProvider,
   getPublicParams,
   getTfheCompactPublicKey,
@@ -49,7 +50,7 @@ export type FhevmInstance = {
     startTimestamp: string | number,
     durationDays: string | number,
   ) => EIP712;
-  publicDecrypt: (handle: string | Uint8Array) => Promise<bigint>;
+  publicDecrypt: (handles: (string | Uint8Array)[]) => Promise<any>;
   userDecrypt: (
     handles: HandleContractPair[],
     privateKey: string,
@@ -107,6 +108,8 @@ export const createInstance = async (
 
   const kmsSigners = await getKMSSigners(provider, config);
 
+  const thresholdSigners = await getKMSSignersThreshold(provider, config);
+
   return {
     createEncryptedInput: createRelayerEncryptedInput(
       aclContractAddress,
@@ -123,8 +126,8 @@ export const createInstance = async (
     ),
     publicDecrypt: publicDecryptRequest(
       kmsSigners,
+      thresholdSigners,
       gatewayChainId,
-      chainId,
       verifyingContractAddress,
       aclContractAddress,
       cleanURL(config.relayerUrl),

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,10 @@ import {
   createRelayerEncryptedInput,
   RelayerEncryptedInput,
 } from './relayer/sendEncryption';
-import { publicDecryptRequest } from './relayer/publicDecrypt';
+import {
+  publicDecryptRequest,
+  DecryptedResults,
+} from './relayer/publicDecrypt';
 
 import { PublicParams } from './sdk/encrypt';
 import { generateKeypair, createEIP712, EIP712 } from './sdk/keypair';
@@ -50,7 +53,9 @@ export type FhevmInstance = {
     startTimestamp: string | number,
     durationDays: string | number,
   ) => EIP712;
-  publicDecrypt: (handles: (string | Uint8Array)[]) => Promise<any>;
+  publicDecrypt: (
+    handles: (string | Uint8Array)[],
+  ) => Promise<Record<string, DecryptedResults>>;
   userDecrypt: (
     handles: HandleContractPair[],
     privateKey: string,

--- a/src/relayer/publicDecrypt.test.ts
+++ b/src/relayer/publicDecrypt.test.ts
@@ -11,8 +11,8 @@ describe('publicDecrypt', () => {
   it('get public decryption for handle', async () => {
     const public_decrypt = publicDecryptRequest(
       [],
+      1,
       54321,
-      9000,
       '0x8ba1f109551bd432803012645ac136ddd64dba72',
       '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
       'https://test-relayer.net/',

--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -178,7 +178,7 @@ export const publicDecryptRequest =
       response = await fetch(`${relayerUrl}/v1/public-decrypt`, options);
       if (!response.ok) {
         throw new Error(
-          `User decrypt failed: relayer respond with HTTP code ${response.status}`,
+          `Public decrypt failed: relayer respond with HTTP code ${response.status}`,
         );
       }
     } catch (e) {

--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -1,28 +1,73 @@
 import { fromHexString, toHexString } from '../utils';
-import { ethers } from 'ethers';
+import { ethers, Interface } from 'ethers';
 
-const aclABI = [
-  'function persistAllowed(bytes32 handle, address account) view returns (bool)',
-];
+const aclABI = new Interface([
+  'function isAllowedForDecryption(bytes32 handle) view returns (bool)',
+]);
+
+function isThresholdReached(
+  kmsSigners: string[],
+  recoveredAddresses: string[],
+  threshold: number,
+): boolean {
+  const addressMap = new Map<string, number>();
+  recoveredAddresses.forEach((address, index) => {
+    if (addressMap.has(address)) {
+      const duplicateValue = address;
+      throw new Error(
+        `Duplicate signer address found: ${duplicateValue} appears multiple times in recovered addresses`,
+      );
+    }
+    addressMap.set(address, index);
+  });
+
+  for (const address of recoveredAddresses) {
+    if (!kmsSigners.includes(address)) {
+      throw new Error(
+        `Invalid address found: ${address} is not in the list of KMS signers`,
+      );
+    }
+  }
+
+  return recoveredAddresses.length >= threshold;
+}
 
 export const publicDecryptRequest =
   (
-    kmsSignatures: string[],
+    kmsSigners: string[],
+    thresholdSigners: number,
     gatewayChainId: number,
-    chainId: number,
     verifyingContractAddress: string,
     aclContractAddress: string,
     relayerUrl: string,
     provider: ethers.JsonRpcProvider | ethers.BrowserProvider,
   ) =>
-  async (_handle: Uint8Array | string) => {
-    const handle =
-      typeof _handle === 'string'
-        ? toHexString(fromHexString(_handle), true)
-        : toHexString(_handle, true);
+  async (_handles: (Uint8Array | string)[]) => {
+    const handles = _handles.map((handle) =>
+      typeof handle === 'string'
+        ? toHexString(fromHexString(handle), true)
+        : toHexString(handle, true),
+    );
+
+    const acl = new ethers.Contract(aclContractAddress, aclABI, provider);
+
+    const verifications = handles.map(async (ctHandle) => {
+      const isAllowedForDecryption = await acl.isAllowedForDecryption(ctHandle);
+      if (!isAllowedForDecryption) {
+        throw new Error(
+          `Handle ${ctHandle} is not allowed for public decryption!`,
+        );
+      }
+    });
+
+    await Promise.all(verifications).catch((e) => {
+      throw e;
+    });
+
+    // TODO: check 2048 bits limit
 
     const payloadForRequest = {
-      ciphertext_handle: handle,
+      ciphertextHandles: handles,
     };
     const options = {
       method: 'POST',
@@ -62,7 +107,47 @@ export const publicDecryptRequest =
       );
     }
 
-    // TODO verify signature on decryption
+    // verify signatures on decryption:
+    const domain = {
+      name: 'Decryption',
+      version: '1',
+      chainId: gatewayChainId,
+      verifyingContract: verifyingContractAddress,
+    };
+    const types = {
+      PublicDecryptVerification: [
+        { name: 'ctHandles', type: 'bytes32[]' },
+        { name: 'decryptedResult', type: 'bytes' },
+      ],
+    };
+    const result = json.response[0];
+    const decryptedResult = result.decrypted_value.startsWith('0x')
+      ? result.decrypted_value
+      : `0x${result.decrypted_value}`;
+    const signatures = result.signatures;
+
+    const recoveredAddresses = signatures.map((signature: string) => {
+      const sig = signature.startsWith('0x') ? signature : `0x${signature}`;
+      const recoveredAddress = ethers.verifyTypedData(
+        domain,
+        types,
+        { ctHandles: handles, decryptedResult: decryptedResult },
+        sig,
+      );
+      return recoveredAddress;
+    });
+
+    const thresholdReached = isThresholdReached(
+      kmsSigners,
+      recoveredAddresses,
+      thresholdSigners,
+    );
+
+    if (!thresholdReached) {
+      throw Error('KMS signers threshold is not reached');
+    }
+
+    // TODO deserialization + abi decoding
 
     return json;
   };

--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -1,6 +1,8 @@
 import { fromHexString, toHexString } from '../utils';
 import { ethers, AbiCoder } from 'ethers';
 
+export type DecryptedResults = Record<string, bigint | boolean | string>;
+
 const aclABI = [
   'function isAllowedForDecryption(bytes32 handle) view returns (bool)',
 ];
@@ -92,7 +94,7 @@ const CiphertextType: Record<number, 'bool' | 'uint256' | 'address' | 'bytes'> =
 function deserializeDecryptedResult(
   handles: string[],
   decryptedResult: string,
-): Record<string, any> {
+): Record<string, DecryptedResults> {
   let typesList: number[] = [];
   for (const handle of handles) {
     const hexPair = handle.slice(-4, -2).toLowerCase();
@@ -120,7 +122,7 @@ function deserializeDecryptedResult(
   // strip dummy first/last element
   const rawValues = decoded.slice(1, 1 + typesList.length);
 
-  let results: Record<string, any> = {};
+  let results: Record<string, DecryptedResults> = {};
   handles.forEach((handle, idx) => (results[handle] = rawValues[idx]));
 
   return results;

--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -1,9 +1,9 @@
 import { fromHexString, toHexString } from '../utils';
-import { ethers, Interface } from 'ethers';
+import { ethers } from 'ethers';
 
-const aclABI = new Interface([
+const aclABI = [
   'function isAllowedForDecryption(bytes32 handle) view returns (bool)',
-]);
+];
 
 function isThresholdReached(
   kmsSigners: string[],

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -5,11 +5,11 @@ import {
   process_user_decryption_resp_from_js,
   u8vec_to_cryptobox_sk,
 } from 'node-tkms';
-import { ethers, getAddress } from 'ethers';
+import { ethers, getAddress, Interface } from 'ethers';
 
-const aclABI = [
+const aclABI = new Interface([
   'function persistAllowed(bytes32 handle, address account) view returns (bool)',
-];
+]);
 
 export type HandleContractPair = {
   ctHandle: Uint8Array | string;
@@ -63,16 +63,18 @@ export const userDecryptRequest =
         contractAddress,
       );
       if (!userAllowed) {
-        throw new Error('User is not authorized to user decrypt this handle!');
+        throw new Error(
+          `User ${userAddress} is not authorized to user decrypt handle ${ctHandle}!`,
+        );
       }
       if (!contractAllowed) {
         throw new Error(
-          'dApp contract is not authorized to user decrypt this handle!',
+          `dapp contract ${contractAddress} is not authorized to user decrypt handle ${ctHandle}!`,
         );
       }
       if (userAddress === contractAddress) {
         throw new Error(
-          'userAddress should not be equal to contractAddress when requesting user decryption!',
+          `userAddress ${userAddress} should not be equal to contractAddress when requesting reencryption!`,
         );
       }
     });

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -5,11 +5,11 @@ import {
   process_user_decryption_resp_from_js,
   u8vec_to_cryptobox_sk,
 } from 'node-tkms';
-import { ethers, getAddress, Interface } from 'ethers';
+import { ethers, getAddress } from 'ethers';
 
-const aclABI = new Interface([
+const aclABI = [
   'function persistAllowed(bytes32 handle, address account) view returns (bool)',
-]);
+];
 
 export type HandleContractPair = {
   ctHandle: Uint8Array | string;

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -74,7 +74,7 @@ export const userDecryptRequest =
       }
       if (userAddress === contractAddress) {
         throw new Error(
-          `userAddress ${userAddress} should not be equal to contractAddress when requesting reencryption!`,
+          `userAddress ${userAddress} should not be equal to contractAddress when requesting user decryption!`,
         );
       }
     });


### PR DESCRIPTION
… endpoint
ex usage: 
```js  
it("test HTTPPublicDecrypt mixed", async function () {
    const handleBool = await this.contract.xBool();
    const handle32 = await this.contract.xUint32();
    const handleAddress = await this.contract.xAddress();
    const handleBytes128 = await this.contract.xBytes128();
    const res = await this.instances.alice.publicDecrypt([
      handleBool,
      handleBytes128,
      handle32,
      handleAddress,
    ]);
    console.log(res);
  });
  ```
  
  Which will return a dictionary of (handles, decrypted cleartext) values such as: 
  `{
  '0x826feb7d3125d43475f3710144322d5eeabe22df63ff00000000000030390000': true,
  '0x48c1b3df0b6e96d395c1d4f0dc88f7688261c26eb0ff00000000000030390a00': '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d3f1e794f90b63477d50293f0ff0d232ca3f485213a1',
  '0xf94fd2cead277005511f811497a185db1b81598f2aff00000000000030390400': 242n,
  '0x207db7f48ef83342828ff2084e891be48f9db07691ff00000000000030390700': '0xfC4382C084fCA3f4fB07c3BCDA906C01797595a8'
}`.
Question: I guess the userDecrypt should also return such a dictionary instead of a list, since we now support also batch user decryption. Also probably it would make sense to add the 2048 encrypted bits check for user Decrypt, wdyt? @immortal-tofu 